### PR TITLE
Add/update MicroPython v1.12 frozen stubs

### DIFF
--- a/stubs/micropython-v1_12-frozen/GENERIC/modules.json
+++ b/stubs/micropython-v1_12-frozen/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-v1_12-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/esp32/RELEASE/modules.json
+++ b/stubs/micropython-v1_12-frozen/esp32/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/esp32/TINYPICO/modules.json
+++ b/stubs/micropython-v1_12-frozen/esp32/TINYPICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-v1_12-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/esp8266/RELEASE/modules.json
+++ b/stubs/micropython-v1_12-frozen/esp8266/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-v1_12-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_12-frozen/stm32/PYBD_SF2/modules.json
+++ b/stubs/micropython-v1_12-frozen/stm32/PYBD_SF2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython v1.12 frozen stubs
based on micropython commit '1f3719473 all: Bump version to 1.12.'