### PR TITLE
Add/update MicroPython v1.18 frozen stubs

### DIFF
--- a/stubs/micropython-v1_18-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/LOLIN_S2_MINI/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/LOLIN_S2_MINI/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/LOLIN_S2_PICO/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/LOLIN_S2_PICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/M5STACK_ATOM/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/M5STACK_ATOM/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/RELEASE/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/UM_FEATHERS2/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/UM_FEATHERS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/UM_FEATHERS2NEO/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/UM_FEATHERS2NEO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/UM_TINYPICO/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/UM_TINYPICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp32/UM_TINYS2/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp32/UM_TINYS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/esp8266/GENERIC_512K/modules.json
+++ b/stubs/micropython-v1_18-frozen/esp8266/GENERIC_512K/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/mimxrt/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/mimxrt/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/rp2/ARDUINO_NANO_RP2040_CONNECT/modules.json
+++ b/stubs/micropython-v1_18-frozen/rp2/ARDUINO_NANO_RP2040_CONNECT/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/rp2/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/rp2/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/samd/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/samd/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/stm32/GARATRONIC_PYBSTICK26_F411/modules.json
+++ b/stubs/micropython-v1_18-frozen/stm32/GARATRONIC_PYBSTICK26_F411/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-v1_18-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_18-frozen/stm32/PYBD_SF2/modules.json
+++ b/stubs/micropython-v1_18-frozen/stm32/PYBD_SF2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a2",
+        "version": "1.5.5a4",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython v1.18 frozen stubs
based on micropython commit 'da4b38e75 all: Bump version to 1.18.'