### PR TITLE
Add/update MicroPython v1.9.4 frozen stubs

### DIFF
--- a/stubs/micropython-v1_9_4-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-v1_9_4-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_9_4-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-v1_9_4-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_9_4-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-v1_9_4-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_9_4-frozen/unix/GENERIC/modules.json
+++ b/stubs/micropython-v1_9_4-frozen/unix/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython v1.9.4 frozen stubs
based on micropython commit '421b84af9 docs: Bump version to 1.9.4.'