### PR TITLE
Add/update MicroPython v1.15 frozen stubs

### DIFF
--- a/stubs/micropython-v1_15-frozen/GENERIC/modules.json
+++ b/stubs/micropython-v1_15-frozen/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-v1_15-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/esp32/RELEASE/modules.json
+++ b/stubs/micropython-v1_15-frozen/esp32/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/esp32/TINYPICO/modules.json
+++ b/stubs/micropython-v1_15-frozen/esp32/TINYPICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-v1_15-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-v1_15-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_15-frozen/stm32/PYBD_SF2/modules.json
+++ b/stubs/micropython-v1_15-frozen/stm32/PYBD_SF2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython v1.15 frozen stubs
based on micropython commit '321d1897c all: Bump version to 1.15.'