### PR TITLE
Add/update MicroPython v1.17 frozen stubs

### DIFF
--- a/stubs/micropython-v1_17-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp32/M5STACK_ATOM/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/M5STACK_ATOM/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp32/RELEASE/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp32/UM_FEATHERS2/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/UM_FEATHERS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp32/UM_TINYPICO/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/UM_TINYPICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp32/UM_TINYS2/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp32/UM_TINYS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/esp8266/GENERIC_512K/modules.json
+++ b/stubs/micropython-v1_17-frozen/esp8266/GENERIC_512K/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/mimxrt/GENERIC/modules.json
+++ b/stubs/micropython-v1_17-frozen/mimxrt/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/rp2/GENERIC/modules.json
+++ b/stubs/micropython-v1_17-frozen/rp2/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-v1_17-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-v1_17-frozen/stm32/PYBD_SF2/modules.json
+++ b/stubs/micropython-v1_17-frozen/stm32/PYBD_SF2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython v1.17 frozen stubs
based on micropython commit '7c54b6428 all: Bump version to 1.17.'