### PR TITLE
Add/update MicroPython Latest frozen stubs

### DIFF
--- a/stubs/micropython-latest-frozen/esp32/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/LOLIN_S2_MINI/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/LOLIN_S2_MINI/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/LOLIN_S2_PICO/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/LOLIN_S2_PICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/M5STACK_ATOM/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/M5STACK_ATOM/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/RELEASE/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/RELEASE/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_FEATHERS2/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_FEATHERS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_FEATHERS2NEO/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_FEATHERS2NEO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_FEATHERS3/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_FEATHERS3/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_PROS3/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_PROS3/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_TINYPICO/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_TINYPICO/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_TINYS2/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_TINYS2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp32/UM_TINYS3/modules.json
+++ b/stubs/micropython-latest-frozen/esp32/UM_TINYS3/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp8266/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/esp8266/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/esp8266/GENERIC_512K/modules.json
+++ b/stubs/micropython-latest-frozen/esp8266/GENERIC_512K/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/mimxrt/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/mimxrt/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/rp2/ARDUINO_NANO_RP2040_CONNECT/modules.json
+++ b/stubs/micropython-latest-frozen/rp2/ARDUINO_NANO_RP2040_CONNECT/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/rp2/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/rp2/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/samd/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/samd/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/stm32/GARATRONIC_PYBSTICK26_F411/modules.json
+++ b/stubs/micropython-latest-frozen/stm32/GARATRONIC_PYBSTICK26_F411/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/stm32/GENERIC/modules.json
+++ b/stubs/micropython-latest-frozen/stm32/GENERIC/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [

--- a/stubs/micropython-latest-frozen/stm32/PYBD_SF2/modules.json
+++ b/stubs/micropython-latest-frozen/stm32/PYBD_SF2/modules.json
@@ -12,7 +12,7 @@
         "sysname": "micropython"
     },
     "stubber": {
-        "version": "1.5.5a4",
+        "version": "1.6.2",
         "stubtype": "frozen"
     },
     "modules": [


### PR DESCRIPTION
add/update MicroPython Latest frozen stubs
based on micropython commit '665f0e2a6 esp32: Sleep one tick in MICROPY_EVENT_POLL_HOOK.'