### PR TITLE
referecence-stubs/time : Use _Time8Tuple for all relevant time methods.

### DIFF
--- a/micropython-reference/time/__init__.pyi
+++ b/micropython-reference/time/__init__.pyi
@@ -45,8 +45,9 @@ _TicksMs: TypeAlias = int
 _TicksUs: TypeAlias = int
 _TicksCPU: TypeAlias = int
 _Ticks = TypeVar("_Ticks", _TicksMs, _TicksUs, _TicksCPU, int)
+_Time8Tuple: TypeAlias = Tuple[int, int, int, int, int, int, int, int]
 
-def gmtime(secs: int | None = None, /) -> Tuple:
+def gmtime(secs: int | None = None, /) -> _Time8Tuple:
     """
     Convert the time *secs* expressed in seconds since the Epoch (see above) into an
     8-tuple which contains: ``(year, month, mday, hour, minute, second, weekday, yearday)``
@@ -68,7 +69,7 @@ def gmtime(secs: int | None = None, /) -> Tuple:
     """
     ...
 
-def localtime(secs: int | None = None, /) -> Tuple:
+def localtime(secs: int | None = None, /) -> _Time8Tuple:
     """
     Convert the time *secs* expressed in seconds since the Epoch (see above) into an
     8-tuple which contains: ``(year, month, mday, hour, minute, second, weekday, yearday)``
@@ -90,7 +91,7 @@ def localtime(secs: int | None = None, /) -> Tuple:
     """
     ...
 
-def mktime(local_time: tuple[int, int, int, int, int, int, int, int], /) -> int:
+def mktime(local_time: _Time8Tuple, /) -> int:
     """
     This is inverse function of localtime. It's argument is a full 8-tuple
     which expresses a time as per localtime. It returns an integer which is


### PR DESCRIPTION
also see: https://github.com/Josverl/micropython-stubs/issues/771