### PR TITLE
Add MicroPython builtins support in stdlib

### DIFF
--- a/docs/22_static_type_checking.md
+++ b/docs/22_static_type_checking.md
@@ -25,6 +25,25 @@ When MicroPython code is compiled to .mpy or frozen into a firmware, the microco
    - Collaboration: When working in teams, type hints enhance collaboration and reduce misunderstandings.
    - Critical Code Paths: Use static type checking for critical parts of your application to prevent subtle bugs.
 
+## MicroPython compiler builtins
+
+MicroPython recognizes `const`, `ptr`, `ptr8`, `ptr16`, `ptr32`, and `uint` as compiler-provided names. The pointer types and `uint` are primarily used with the `@micropython.viper` emitter:
+
+```python
+import micropython
+
+@micropython.viper
+def read_byte(buffer: bytearray, offset: int) -> uint:
+    data = ptr8(buffer)
+    return uint(data[offset])
+```
+
+The stdlib stub package declares these names in its custom `builtins.pyi`. Pyright and Pylance additionally receive them through the MicroPython core `__builtins__.pyi` overlay. Mypy resolves them when `custom_typeshed_dir` points to the installed MicroPython stdlib stubs. Basilisk resolves them when `typeshed-path` points to those stubs.
+
+Ty has an equivalent `[tool.ty.environment] typeshed` setting, which the setup script configures. Ty 0.0.65 currently crashes while loading this custom stdlib, so support cannot yet be validated. Ruff does not load type stubs; configure its `builtins` setting as described in {ref}`ruff_config`.
+
+Type checkers and linters expose these names globally. They cannot enforce MicroPython's rule that pointer operations are valid only in native/Viper code, so code outside those functions may still pass static checks and fail when compiled or run.
+
 ## Alternative Method: Static Type Checking without a Typing Module
 
 In some cases, you may want to perform static type checking without using a typing module. This can be achieved using the `TYPE_CHECKING` constant and conditional imports. This method allows you to include type hints and imports only when performing static type checking, without affecting the runtime behavior of your code.

--- a/docs/29_ruff.md
+++ b/docs/29_ruff.md
@@ -36,6 +36,7 @@ Ruff can be configured in your `pyproject.toml` file. For MicroPython stubs, we 
 [tool.ruff]
 line-length = 140
 target-version = "py39"
+builtins = ["ptr", "ptr8", "ptr16", "ptr32", "uint", "micropython", "const"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -44,7 +45,6 @@ extend-select = [
 ignore = [
     "F401",   # unused import
     "F403",   # import *
-    "F821",   # undefined name (can occur in stubs)
     "E402",   # module level import not at top of file - common in test snippets
     "PYI021", # Docstrings should not be included in stubs (but we want them for MicroPython)
     "PYI044", # `from __future__ import annotations` - used in generated stubs
@@ -54,6 +54,8 @@ ignore = [
     "PYI029", # __str__ and __repr__ are useful in MicroPython stubs
 ]
 ```
+
+The `builtins` list prevents undefined-name diagnostics for names provided directly by the MicroPython compiler. Ruff does not read `builtins.pyi`, so this setting is required independently of type-checker configuration.
 
 ## Running Ruff
 

--- a/examples/src/pyproject.toml
+++ b/examples/src/pyproject.toml
@@ -78,3 +78,14 @@ output-format = "full"
 error-on-warning = false
 
 # ###################################################################
+# ruff options:
+
+[tool.ruff]
+line-length = 140
+target-version = "py39"
+builtins = ["ptr", "ptr8", "ptr16", "ptr32", "uint", "micropython", "const"]
+
+[tool.ruff.lint]
+extend-select = ["PYI"]
+
+# ###################################################################

--- a/publish/micropython-stdlib-stubs/build.py
+++ b/publish/micropython-stdlib-stubs/build.py
@@ -409,6 +409,31 @@ def patch_sys_implementation(dist_stdlib_path: Path):
         log.info("Patched stdlib/sys/__init__.pyi for MicroPython sys.implementation")
 
 
+def patch_micropython_builtins(reference_path: Path, dist_stdlib_path: Path):
+    """Expose compiler-provided names through the custom stdlib builtins module."""
+    builtins_stub = dist_stdlib_path / "stdlib/builtins.pyi"
+    source_stub = reference_path / "_mpy_shed/_mpy_builtins.pyi"
+    if not builtins_stub.exists():
+        log.warning(f"Could not patch MicroPython builtins, file not found: {builtins_stub}")
+        return
+    if not source_stub.exists():
+        raise FileNotFoundError(f"MicroPython builtins source not found: {source_stub}")
+
+    content = builtins_stub.read_text(encoding="utf-8")
+    source = source_stub.read_text(encoding="utf-8")
+    match = re.search(r"# BEGIN: BUILTINS\n(?P<declarations>.*?)# END: BUILTINS", source, flags=re.DOTALL)
+    if match is None:
+        raise RuntimeError(f"MicroPython builtins declaration block not found: {source_stub}")
+
+    declarations = match.group("declarations").rstrip()
+    if declarations not in content:
+        marker = "class object:"
+        if marker not in content:
+            raise RuntimeError("Could not locate object class in stdlib/builtins.pyi")
+        builtins_stub.write_text(content.replace(marker, f"{declarations}\n\n{marker}", 1), encoding="utf-8")
+        log.info("Patched stdlib/builtins.pyi for MicroPython compiler-provided builtins")
+
+
 def patch_asyncio_support(reference_path: Path, dist_stdlib_path: Path):
     """Ensure asyncio resolves Task/Future from MicroPython's private _asyncio module."""
     stdlib_path = dist_stdlib_path / "stdlib"
@@ -437,6 +462,7 @@ def patch_asyncio_support(reference_path: Path, dist_stdlib_path: Path):
 
 def apply_micropython_patches(reference_path: Path, dist_stdlib_path: Path):
     """Apply deterministic MicroPython-specific patches after stdlib generation."""
+    patch_micropython_builtins(reference_path, dist_stdlib_path)
     patch_sys_implementation(dist_stdlib_path)
     patch_asyncio_support(reference_path, dist_stdlib_path)
 

--- a/reference/_mpy_shed/_mpy_builtins.pyi
+++ b/reference/_mpy_shed/_mpy_builtins.pyi
@@ -1,16 +1,16 @@
 """MicroPython compiler-provided builtins for static type checkers."""
 
 from _typeshed import ReadableBuffer
-from typing import TypeVar
+from typing import Any, Mapping, TypeVar
 from typing_extensions import Self, TypeAlias
 
 # BEGIN: BUILTINS
-Const_T = TypeVar("Const_T", int, float, str, bytes, tuple)
+Const_T = TypeVar("Const_T", int, float, str, bytes, tuple)  # noqa: PYI001
 
 #: Unsigned machine-word integer used by the Viper emitter. This type is
 #: primarily useful as a Viper function return annotation. It makes MicroPython
 #: interpret ``0xffffffff`` as ``2**32 - 1`` rather than ``-1``.
-uint: TypeAlias = int
+uint: TypeAlias = int  # noqa: PYI042
 
 class ptr(int):
     """Viper pointer to an object or memory address.
@@ -59,6 +59,15 @@ def const(expr: Const_T, /) -> Const_T:
     MicroPython may substitute the value during compilation. A name beginning
     with an underscore is hidden from module globals and consumes no runtime
     storage.
+    """
+    ...
+
+def execfile(filename: str, globals: dict[str, Any] | None = None, locals: Mapping[str, object] | None = None, /) -> None:
+    """Execute the file *filename* with semantics equivalent to Python 2's ``execfile``.
+
+    Only available on ports/builds with ``MICROPY_PY_BUILTINS_EXECFILE`` enabled
+    (disabled by default on most embedded ports). Unlike `exec`, *filename* must
+    be a `str`; passing anything else (including `bytes`) raises `TypeError`.
     """
     ...
 

--- a/reference/_mpy_shed/_mpy_builtins.pyi
+++ b/reference/_mpy_shed/_mpy_builtins.pyi
@@ -1,0 +1,65 @@
+"""MicroPython compiler-provided builtins for static type checkers."""
+
+from _typeshed import ReadableBuffer
+from typing import TypeVar
+from typing_extensions import Self, TypeAlias
+
+# BEGIN: BUILTINS
+Const_T = TypeVar("Const_T", int, float, str, bytes, tuple)
+
+#: Unsigned machine-word integer used by the Viper emitter. This type is
+#: primarily useful as a Viper function return annotation. It makes MicroPython
+#: interpret ``0xffffffff`` as ``2**32 - 1`` rather than ``-1``.
+uint: TypeAlias = int
+
+class ptr(int):
+    """Viper pointer to an object or memory address.
+
+    Create a pointer from an integer address or an object supporting the buffer
+    protocol. Plain ``ptr`` values are not subscriptable; use a sized pointer
+    type for direct memory access.
+
+    Pointer operations are only valid in native/Viper code and do not perform
+    bounds checks. Invalid addresses or indexes can corrupt memory or crash the
+    device.
+    """
+
+    def __new__(cls, value: int | ReadableBuffer, /) -> Self: ...
+
+class ptr8(ptr):
+    """Viper pointer providing indexed access to unsigned 8-bit bytes.
+
+    Indexes address individual bytes. Slices and bounds checks are not supported.
+    """
+
+    def __getitem__(self, index: int, /) -> int: ...
+    def __setitem__(self, index: int, value: int, /) -> None: ...
+
+class ptr16(ptr):
+    """Viper pointer providing indexed access to unsigned 16-bit half-words.
+
+    Indexes are scaled by two bytes. Slices and bounds checks are not supported.
+    """
+
+    def __getitem__(self, index: int, /) -> int: ...
+    def __setitem__(self, index: int, value: int, /) -> None: ...
+
+class ptr32(ptr):
+    """Viper pointer providing indexed access to unsigned 32-bit machine words.
+
+    Indexes are scaled by four bytes. Slices and bounds checks are not supported.
+    """
+
+    def __getitem__(self, index: int, /) -> int: ...
+    def __setitem__(self, index: int, value: int, /) -> None: ...
+
+def const(expr: Const_T, /) -> Const_T:
+    """Declare an expression as a compile-time constant.
+
+    MicroPython may substitute the value during compilation. A name beginning
+    with an underscore is hidden from module globals and consumes no runtime
+    storage.
+    """
+    ...
+
+# END: BUILTINS

--- a/setup_micropython_stubs.py
+++ b/setup_micropython_stubs.py
@@ -29,10 +29,9 @@ PYPROJECT_TEMPLATE_URL = f"{REPO_ROOT_URL}/examples/src/pyproject.toml"
 
 
 DEFAULT_STABLE_VERSION = "v1.28.0.*"
-KNOWN_TYPE_CHECKERS = {"pyright", "mypy", "ty", "pyrefly", "zuban"}
+KNOWN_TYPE_CHECKERS = {"pyright", "mypy", "ty", "pyrefly", "zuban", "ruff"}
 TYPE_CHECKER_NONE = "none"
 DEFAULT_SOURCE_LOCATION = "src"
-
 
 
 # qprint
@@ -40,30 +39,28 @@ STYLE_BOLD = "bold green"
 STYLE_NORMAL = "cyan"
 STYLE_WARNING = "bold darkorange"
 
-STUB_STYLE= Style(
-        [
-            ("qmark", "limegreen bold"),  # "?" prefix — bold, inherits fg
-            ("question", "bold"),  # question text
-            ("answer", "fg:green bold"),  # confirmed answer
-            ("pointer", "fg:forestgreen bold"),  # selection cursor
-            ("selected", "fg:green"),  # ticked checkbox item
-            ("search_success", "bold fg:limegreen"),
-            ("search_none", "bold fg:red"),
-            ("highlighted", "fg: yellow bold bg:limegreen"), # currently highlighted autocomplete match
-            ("separator", "fg:default"),
-            ("instruction", "fg:default italic"),
-            ("text", STYLE_NORMAL),
-            # Autocomplete dropdown — dark background, dim text, no glare
-            ("completion-menu", "bg:ansiblack fg:ansiwhite"),
-            ("completion-menu.completion", "bg:ansiblack fg:ansiwhite"),
-            ("completion-menu.completion.current", "bg:ansidarkgray fg:ansimagenta bold"),
-            ("completion-menu.meta", "bg:ansiblack fg:ansidarkgray"),
-            ("completion-menu.meta.completion", "bg:ansiblack fg:ansidarkgray"),
-            ("completion-menu.meta.completion.current", "bg:ansiyellow fg:ansigray"),
-        ]
+STUB_STYLE = Style(
+    [
+        ("qmark", "limegreen bold"),  # "?" prefix — bold, inherits fg
+        ("question", "bold"),  # question text
+        ("answer", "fg:green bold"),  # confirmed answer
+        ("pointer", "fg:forestgreen bold"),  # selection cursor
+        ("selected", "fg:green"),  # ticked checkbox item
+        ("search_success", "bold fg:limegreen"),
+        ("search_none", "bold fg:red"),
+        ("highlighted", "fg: yellow bold bg:limegreen"),  # currently highlighted autocomplete match
+        ("separator", "fg:default"),
+        ("instruction", "fg:default italic"),
+        ("text", STYLE_NORMAL),
+        # Autocomplete dropdown — dark background, dim text, no glare
+        ("completion-menu", "bg:ansiblack fg:ansiwhite"),
+        ("completion-menu.completion", "bg:ansiblack fg:ansiwhite"),
+        ("completion-menu.completion.current", "bg:ansidarkgray fg:ansimagenta bold"),
+        ("completion-menu.meta", "bg:ansiblack fg:ansidarkgray"),
+        ("completion-menu.meta.completion", "bg:ansiblack fg:ansidarkgray"),
+        ("completion-menu.meta.completion.current", "bg:ansiyellow fg:ansigray"),
+    ]
 )
-
-
 
 
 def _ty_typeshed_dir_name(stub_path: str) -> str:
@@ -170,6 +167,7 @@ def filter_packages_by_version(candidates: list[StubPackage], version: str) -> l
 
     return [pkg for pkg in candidates if _normalize_version(pkg.version) == req_version]
 
+
 def extract_tool_sections(template: str) -> dict[str, str]:
     pattern = re.compile(r"(?ms)^\[tool\.(?P<name>[^\]]+)\]\n(?P<body>.*?)(?=^\[tool\.|\Z)")
     sections: dict[str, str] = {}
@@ -219,7 +217,7 @@ def source_location_choices(project_dir: str | Path) -> list[str]:
     choices = [DEFAULT_SOURCE_LOCATION, "."]
     if project_root.exists() and project_root.is_dir():
         for child in sorted(project_root.iterdir()):
-            if child.is_dir() and not child.name.startswith((".", "_","typings")):
+            if child.is_dir() and not child.name.startswith((".", "_", "typings")):
                 choices.append(child.name)
 
     ordered: list[str] = []
@@ -251,6 +249,7 @@ def prompt_for_selection(message: str, choices: list[str], default: str | None =
     if not answer:
         raise SystemExit("Setup cancelled before applying changes.")
     return answer
+
 
 def prompt_for_gitignore_update(project_dir: Path, pattern: str) -> bool:
     if not sys.stdin.isatty() or not sys.stdout.isatty():
@@ -329,12 +328,7 @@ def _toml_escape(value: str) -> str:
 
 def _initial_project_section(project_dir: Path) -> str:
     project_name = _toml_escape(project_dir.resolve().name)
-    return (
-        "[project]\n"
-        f'name = "{project_name}"\n'
-        'version = "0.1.0"\n'
-        'description = "A MicroPython project"\n'
-    )
+    return f'[project]\nname = "{project_name}"\nversion = "0.1.0"\ndescription = "A MicroPython project"\n'
 
 
 def _render_optional_dependencies_body(existing_body: str, requirement: str, target: str) -> str:
@@ -401,6 +395,7 @@ def write_optional_dependencies(pyproject_path: Path, package: StubPackage, targ
     merged = _upsert_toml_section(existing_text, section_header=section_header, section_text=section_text)
     pyproject_path.write_text(merged, encoding="utf-8")
     qprint(f"Updated [{section_header}] stubs dependency: {requirement}", style=STYLE_NORMAL)
+
 
 def ensure_gitignore_typings_with_mode(project_dir: Path, mode: str) -> None:
     gitignore = project_dir / ".gitignore"
@@ -519,8 +514,7 @@ def install_stubs(package: StubPackage, target: Path) -> None:
         ]
     else:
         raise RuntimeError(
-            "Could not install stubs: none of 'uv', 'pipx', or 'pip' is available. "
-            "Install uv, or install pipx/pip and retry."
+            "Could not install stubs: none of 'uv', 'pipx', or 'pip' is available. Install uv, or install pipx/pip and retry."
         )
 
     qprint(f"Install command: {' '.join(cmd)}", style=STYLE_NORMAL)
@@ -586,7 +580,6 @@ def build_ty_stdlib_typeshed(typings_dir: Path, output_dir: Path, clean: bool = 
     qprint(f"Created Ty stdlib typeshed at: {merged_stdlib}", style=STYLE_NORMAL)
 
 
-
 def cli_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Set up MicroPython stubs in a local project using uv.")
     parser.add_argument("--package", help="Exact package name (for example: micropython-rp2-rpi_pico_w-stubs).")
@@ -601,7 +594,9 @@ def cli_parser() -> argparse.ArgumentParser:
         "--type-checker",
         help="Static type checker section to merge from template (for example: pyright, mypy) or 'none' to skip pyproject changes.",
     )
-    parser.add_argument("--force", action="store_true", help="Overwrite existing checker sections when they differ from recommended settings.")
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite existing checker sections when they differ from recommended settings."
+    )
     parser.add_argument(
         "--update-gitignore",
         choices=["ask", "always", "never"],
@@ -642,7 +637,7 @@ def main(argv: list[str] | None = None) -> int:
     gitignore_mode = args.update_gitignore
 
     needs_upfront_form = (not type_checker) or (not package_name)
-    if needs_upfront_form: 
+    if needs_upfront_form:
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
             parser.error("Insufficient CLI options provided, interactive form requires a TTY.")
 
@@ -746,9 +741,7 @@ def main(argv: list[str] | None = None) -> int:
     if type_checker is not None:
         selected_sections = sections_for_type_checker(sections, type_checker)
         if not selected_sections:
-            parser.error(
-                f"Type checker '{type_checker}' not found in template. Available options: {', '.join(checkers)}"
-            )
+            parser.error(f"Type checker '{type_checker}' not found in template. Available options: {', '.join(checkers)}")
 
         for section_header, section_text in selected_sections:
             update_pyproject(config_path, section_header=section_header, section_text=section_text, force=args.force)
@@ -771,4 +764,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/stubs/micropython-core/__builtins__.pyi
+++ b/stubs/micropython-core/__builtins__.pyi
@@ -1,28 +1,8 @@
-"""Allows for type checking of Micropython specific builtins by pyright and pylance.
-"""
+"""Allows for type checking of MicroPython-specific builtins by Pyright and Pylance."""
 
-from typing import Tuple, TypeVar
-
-Const_T = TypeVar("Const_T", int, float, str, bytes, Tuple)  # constant
-
-def const(expr: Const_T) -> Const_T:
-    """
-    Used to declare that the expression is a constant so that the compiler can
-    optimise it.  The use of this function should be as follows::
-
-     from micropython import const
-
-     CONST_X = const(123)
-     CONST_Y = const(2 * CONST_X + 1)
-
-    Constants declared this way are still accessible as global variables from
-    outside the module they are declared in.  On the other hand, if a constant
-    begins with an underscore then it is hidden, it is not available as a global
-    variable, and does not take up any memory during execution.
-
-    This `const` function is recognised directly by the MicroPython parser and is
-    provided as part of the :mod:`micropython` module mainly so that scripts can be
-    written which run under both CPython and MicroPython, by following the above
-    pattern.
-    """
-    ...
+from _mpy_shed._mpy_builtins import const as const
+from _mpy_shed._mpy_builtins import ptr as ptr
+from _mpy_shed._mpy_builtins import ptr8 as ptr8
+from _mpy_shed._mpy_builtins import ptr16 as ptr16
+from _mpy_shed._mpy_builtins import ptr32 as ptr32
+from _mpy_shed._mpy_builtins import uint as uint

--- a/tests/quality_tests/_configs/pyproject.toml
+++ b/tests/quality_tests/_configs/pyproject.toml
@@ -56,6 +56,7 @@ warn_unused_ignores = true  # allows to verify the absense of methods/classes in
 [tool.ruff]
 line-length = 140
 target-version = "py39"
+builtins = ["ptr", "ptr8", "ptr16", "ptr32", "uint", "micropython", "const"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/tests/quality_tests/feat_micropython/check_micropython/check_viper.py
+++ b/tests/quality_tests/feat_micropython/check_micropython/check_viper.py
@@ -1,15 +1,20 @@
 import micropython
 
-# https://docs.micropython.org/en/v1.20.0/reference/speed_python.html?highlight=viper#the-viper-code-emitter
-# Casting operators are currently: int, bool, uint, ptr, ptr8, ptr16 and ptr32.
-# todo: micropython.viper - add support for casting operators
+
+@micropython.viper
+def unsigned_word() -> uint:
+    return 0xFFFFFFFF
 
 
 @micropython.viper
-def foo(self, arg: int) -> int:
-    buf = ptr8(self.linebuf)  # type: ignore 
-    for x in range(20, 30):
-        bar = buf[x]  # Access a data item through the pointer
-        # code omitted
-
-    return len(buf)  # Return an integer value
+def read_viper(buffer: bytearray, offset: int, address: ptr) -> uint:
+    byte_pointer = ptr8(buffer)
+    halfword_pointer = ptr16(buffer)
+    word_pointer = ptr32(address)
+    unsigned = uint(byte_pointer[offset])
+    byte_pointer[offset] = unsigned
+    halfword_pointer[offset] = unsigned
+    word_pointer[offset] = unsigned
+    value: int = byte_pointer[offset]
+    value = unsigned
+    return unsigned

--- a/tests/scripts/test_setup_micropython_stubs.py
+++ b/tests/scripts/test_setup_micropython_stubs.py
@@ -126,7 +126,7 @@ def test_main_builds_ty_stdlib_after_install(monkeypatch, tmp_path: Path):
     sleep_calls: list[float] = []
 
     monkeypatch.setattr(mod, "_load_stub_packages_from_url", lambda timeout=15: packages)
-    monkeypatch.setattr(mod, "_load_pyproject_template_from_url", lambda timeout=15: "[tool.ty.src]\ninclude = [\".\"]\n")
+    monkeypatch.setattr(mod, "_load_pyproject_template_from_url", lambda timeout=15: '[tool.ty.src]\ninclude = ["."]\n')
     monkeypatch.setattr(mod.time, "sleep", lambda seconds: sleep_calls.append(seconds))
 
     def _fake_install(package, target: Path):
@@ -189,7 +189,7 @@ stubs = [
     mod.write_optional_dependencies(pyproject, package=pkg, target="typings")
 
     content = pyproject.read_text(encoding="utf-8")
-    assert "dev = [\"pytest\"]" in content
+    assert 'dev = ["pytest"]' in content
     assert "micropython-old-stubs" not in content
     assert '"micropython-esp32-stubs==1.28.0.*"' in content
 
@@ -256,8 +256,8 @@ stubPath = "typings"
     result = pyproject.read_text(encoding="utf-8")
     assert "[tool.black]" in result
     assert "line-length = 120" in result
-    assert "typeCheckingMode = \"basic\"" in result
-    assert "typeCheckingMode = \"standard\"" not in result
+    assert 'typeCheckingMode = "basic"' in result
+    assert 'typeCheckingMode = "standard"' not in result
 
 
 def test_write_pyproject_overwrites_existing_section_with_force(tmp_path: Path):
@@ -286,9 +286,9 @@ stubPath = "typings"
     result = pyproject.read_text(encoding="utf-8")
     assert "[tool.black]" in result
     assert "line-length = 120" in result
-    assert "typeCheckingMode = \"standard\"" in result
-    assert "stubPath = \"typings\"" in result
-    assert "typeCheckingMode = \"basic\"" not in result
+    assert 'typeCheckingMode = "standard"' in result
+    assert 'stubPath = "typings"' in result
+    assert 'typeCheckingMode = "basic"' not in result
 
 
 def test_write_pyproject_appends_missing_section(tmp_path: Path):
@@ -313,7 +313,7 @@ mypy_path = "typings"
     result = pyproject.read_text(encoding="utf-8")
     assert "[tool.black]" in result
     assert "[tool.mypy]" in result
-    assert "mypy_path = \"typings\"" in result
+    assert 'mypy_path = "typings"' in result
 
 
 def test_extract_tool_sections_reads_template_sections():
@@ -360,20 +360,22 @@ def test_available_type_checkers_filters_known_names():
         "mypy": "[tool.mypy]\n",
         "ty.environment": "[tool.ty.environment]\n",
         "ty.src": "[tool.ty.src]\n",
+        "ruff": "[tool.ruff]\n",
+        "ruff.lint": "[tool.ruff.lint]\n",
         "black": "[tool.black]\n",
     }
 
     checkers = mod.available_type_checkers(sections)
 
-    assert checkers == ["mypy", "pyright", "ty"]
+    assert checkers == ["mypy", "pyright", "ruff", "ty"]
 
 
 def test_sections_for_type_checker_includes_nested_ty_sections():
     mod = _load_setup_script_module()
     sections = {
-        "mypy": "[tool.mypy]\nmypy_path = \"typings\"\n",
-        "ty.environment": "[tool.ty.environment]\nextra-paths = [\"typings\"]\n",
-        "ty.src": "[tool.ty.src]\ninclude = [\".\"]\n",
+        "mypy": '[tool.mypy]\nmypy_path = "typings"\n',
+        "ty.environment": '[tool.ty.environment]\nextra-paths = ["typings"]\n',
+        "ty.src": '[tool.ty.src]\ninclude = ["."]\n',
     }
 
     selected = mod.sections_for_type_checker(sections, "ty")
@@ -381,6 +383,21 @@ def test_sections_for_type_checker_includes_nested_ty_sections():
     assert selected == [
         ("tool.ty.environment", sections["ty.environment"]),
         ("tool.ty.src", sections["ty.src"]),
+    ]
+
+
+def test_sections_for_type_checker_includes_ruff_builtins():
+    mod = _load_setup_script_module()
+    sections = {
+        "ruff": '[tool.ruff]\nbuiltins = ["ptr8", "uint", "const"]\n',
+        "ruff.lint": '[tool.ruff.lint]\nextend-select = ["PYI"]\n',
+    }
+
+    selected = mod.sections_for_type_checker(sections, "ruff")
+
+    assert selected == [
+        ("tool.ruff", sections["ruff"]),
+        ("tool.ruff.lint", sections["ruff.lint"]),
     ]
 
 
@@ -473,13 +490,15 @@ def test_main_with_type_checker_none_installs_without_pyproject_changes(monkeypa
     monkeypatch.setattr(
         mod,
         "_load_pyproject_template_from_url",
-        lambda timeout=15: "[tool.pyright]\nstubPath = \"typings\"\n\n[tool.mypy]\nmypy_path = \"typings\"\n",
+        lambda timeout=15: '[tool.pyright]\nstubPath = "typings"\n\n[tool.mypy]\nmypy_path = "typings"\n',
     )
     monkeypatch.setattr(mod.questionary, "select", _select)
     monkeypatch.setattr(mod.questionary, "confirm", lambda *args, **kwargs: _Prompt(True))
     monkeypatch.setattr(mod.questionary, "path", _path)
     monkeypatch.setattr(mod.questionary, "form", _form)
-    monkeypatch.setattr(mod, "update_pyproject", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("pyproject should not be updated")))
+    monkeypatch.setattr(
+        mod, "update_pyproject", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("pyproject should not be updated"))
+    )
     monkeypatch.setattr(
         mod,
         "write_optional_dependencies",
@@ -537,7 +556,7 @@ def test_main_creates_selected_source_folder_when_missing(monkeypatch, tmp_path:
         return _Prompt("src" if len(select_calls) == 1 else "none")
 
     monkeypatch.setattr(mod, "_load_stub_packages_from_url", lambda timeout=15: packages)
-    monkeypatch.setattr(mod, "_load_pyproject_template_from_url", lambda timeout=15: "[tool.mypy]\nmypy_path = \"typings\"\n")
+    monkeypatch.setattr(mod, "_load_pyproject_template_from_url", lambda timeout=15: '[tool.mypy]\nmypy_path = "typings"\n')
     monkeypatch.setattr(mod.questionary, "path", lambda *args, **kwargs: _Prompt(str(tmp_path)))
     monkeypatch.setattr(mod.questionary, "select", _select)
     monkeypatch.setattr(mod.questionary, "confirm", lambda *args, **kwargs: _Prompt(True))
@@ -607,7 +626,9 @@ def test_main_collects_upfront_questions_before_changes(monkeypatch, tmp_path: P
     monkeypatch.setattr(
         mod,
         "_load_pyproject_template_from_url",
-        lambda timeout=15: "[tool.pyright]\ninclude = [\"src\"]\nextraPaths = [\"src/lib\"]\nstubPath = \"typings\"\n\n[tool.mypy]\nfiles = \"src/*.py\"\nmypy_path = \"src/lib,typings\"\n",
+        lambda timeout=15: (
+            '[tool.pyright]\ninclude = ["src"]\nextraPaths = ["src/lib"]\nstubPath = "typings"\n\n[tool.mypy]\nfiles = "src/*.py"\nmypy_path = "src/lib,typings"\n'
+        ),
     )
     monkeypatch.setattr(mod, "install_stubs", lambda package, target: None)
     monkeypatch.setattr(mod, "write_optional_dependencies", lambda *args, **kwargs: None)


### PR DESCRIPTION
Introduce patching for MicroPython builtins in the standard library, enhancing compatibility and functionality. Update tests and configuration to reflect these changes, ensuring proper integration with the ruff linter.