### PR TITLE
Enhance WLAN configuration and update socket recvfrom return type

### DIFF
--- a/reference/micropython/network/WLAN.pyi
+++ b/reference/micropython/network/WLAN.pyi
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Tuple, overload
+from typing import Any, List, Literal, Tuple, overload
 
 from _typeshed import Incomplete
 
@@ -74,7 +74,7 @@ class WLAN:
         """
         ...
 
-    def scan(self) -> List[Tuple]:
+    def scan(self) -> List[Tuple[bytes, bytes, int, int, int, int]]:
         """
         Scan for the available wireless networks.
         Hidden networks -- where the SSID is not broadcast -- will also be scanned
@@ -172,7 +172,27 @@ class WLAN:
         """
 
     @overload
-    def config(self, param: str, /) -> Any:
+    def config(self, param: Literal["mac"], /) -> bytes: ...
+    @overload
+    def config(self, param: Literal["ssid"], /) -> str: ...
+    @overload
+    def config(self, param: Literal["channel"], /) -> int: ...
+    @overload
+    def config(self, param: Literal["hidden"], /) -> bool: ...
+    @overload
+    def config(self, param: Literal["security"], /) -> int: ...
+    @overload
+    def config(self, param: Literal["key"], /) -> str: ...
+    @overload
+    def config(self, param: Literal["hostname"], /) -> str: ...
+    @overload
+    def config(self, param: Literal["reconnects"], /) -> int: ...
+    @overload
+    def config(self, param: Literal["txpower"], /) -> int | float: ...
+    @overload
+    def config(self, param: Literal["pm"], /) -> int: ...
+    @overload
+    def config(self, param: str, /) -> Incomplete:
         """
         Get or set general network interface parameters. These methods allow to work
         with additional parameters beyond standard IP configuration (as dealt with by
@@ -207,7 +227,21 @@ class WLAN:
         """
 
     @overload
-    def config(self, **kwargs: Any) -> None:
+    def config(
+        self,
+        *,
+        mac: bytes = ...,
+        ssid: str = ...,
+        channel: int = ...,
+        hidden: bool = ...,
+        security: int = ...,
+        key: str = ...,
+        hostname: str = ...,
+        reconnects: int = ...,
+        txpower: float = ...,
+        pm: int = ...,
+        **kwargs: Any,
+    ) -> None:
         """
         Get or set general network interface parameters. These methods allow to work
         with additional parameters beyond standard IP configuration (as dealt with by

--- a/reference/micropython/socket/__init__.pyi
+++ b/reference/micropython/socket/__init__.pyi
@@ -219,7 +219,7 @@ class socket:
         """
         ...
 
-    def recvfrom(self, bufsize: int, /) -> Tuple:
+    def recvfrom(self, bufsize: int, /) -> Tuple[bytes, _Address]:
         """
         Receive data from the socket. The return value is a pair *(bytes, address)* where *bytes* is a
         bytes object representing the data received and *address* is the address of the socket sending

--- a/tests/quality_tests/feat_espnow/check_utils/wifi.py
+++ b/tests/quality_tests/feat_espnow/check_utils/wifi.py
@@ -72,12 +72,12 @@ def channel(channel=0):
         raise OSError("can not set channel when connected to wifi network.")
     if _ap.isconnected():
         raise OSError("can not set channel when clients are connected to AP.")
-    if _sta.active() and not is_esp8266: 
+    if _sta.active() and not is_esp8266:
         _sta.config(channel=channel)  # On ESP32 use STA interface
         return _sta.config("channel")
     else:
         # On ESP8266, use the AP interface to set the channel
-        ap_save = _ap.active()  
+        ap_save = _ap.active()
         _ap.active(True)
         _ap.config(channel=channel)
         _ap.active(ap_save)
@@ -120,10 +120,11 @@ def reset(
     _ap.active(ap)
     if sta:
         disconnect()  # For ESP8266
-        try:
-            _sta.config(pm=pm)
-        except ValueError:
-            pass
+        if pm is not None:
+            try:
+                _sta.config(pm=pm)
+            except ValueError:
+                pass
     try:
         wlan = _sta if sta else _ap if ap else None
         if wlan and (protocol is not None):
@@ -138,12 +139,10 @@ def status():
     from binascii import hexlify
 
     for name, w in (("STA", _sta), ("AP", _ap)):
-        active = (
-            "on," if w.active() else "off,"  
-        )
+        active = "on," if w.active() else "off,"
         mac = w.config("mac")
         hex = hexlify(mac, ":").decode()
-        print("{:3s}: {:4s} mac= {} ({})".format(name, active, hex, mac))
+        print("{:3s}: {:4s} mac= {} ({!r})".format(name, active, hex, mac))
     if _sta.isconnected():
         print("     connected:", _sta.config("ssid"), end="")
     else:
@@ -164,13 +163,7 @@ def status():
         mode_names = ("MODE_11B", "MODE_11G", "MODE_11N", "MODE_LR")
         protocol = _sta.config("protocol")
         try:
-            p = "|".join(
-                (
-                    x 
-                    for x in mode_names
-                    if protocol & getattr(network, x)  
-                )
-            )
+            p = "|".join((x for x in mode_names if protocol & getattr(network, x)))
         except AttributeError:
             p = ""
         print(", protocol={:d} ({})".format(protocol, p), end="")
@@ -179,4 +172,3 @@ def status():
     print()
     if _sta.isconnected():
         print("     ifconfig:", _sta.ifconfig())
-

--- a/tests/quality_tests/feat_mypy/wifi.py
+++ b/tests/quality_tests/feat_mypy/wifi.py
@@ -60,7 +60,7 @@ try:
 except AttributeError:
     default_pm_mode = None
 try:
-    default_protocol = network.MODE_11B | network.MODE_11G | network.MODE_11N # stubs-ignore : port not in ["esp32"]
+    default_protocol = network.MODE_11B | network.MODE_11G | network.MODE_11N  # stubs-ignore : port not in ["esp32"]
 except AttributeError:
     default_protocol = None
 
@@ -72,7 +72,7 @@ def channel(channel=0):
         raise OSError("can not set channel when connected to wifi network.")
     if _ap.isconnected():
         raise OSError("can not set channel when clients are connected to AP.")
-    if _sta.active() and not is_esp8266: 
+    if _sta.active() and not is_esp8266:
         _sta.config(channel=channel)  # On ESP32 use STA interface
         return _sta.config("channel")
     else:
@@ -120,10 +120,11 @@ def reset(
     _ap.active(ap)
     if sta:
         disconnect()  # For ESP8266
-        try:
-            _sta.config(pm=pm)
-        except ValueError:
-            pass
+        if pm is not None:
+            try:
+                _sta.config(pm=pm)
+            except ValueError:
+                pass
     try:
         wlan = _sta if sta else _ap if ap else None
         if wlan and (protocol is not None):
@@ -138,12 +139,10 @@ def status():
     from binascii import hexlify
 
     for name, w in (("STA", _sta), ("AP", _ap)):
-        active = (
-            "on," if w.active() else "off,"   
-        )
+        active = "on," if w.active() else "off,"
         mac = w.config("mac")
         hex = hexlify(mac, ":").decode()
-        print("{:3s}: {:4s} mac= {} ({})".format(name, active, hex, mac))
+        print("{:3s}: {:4s} mac= {} ({!r})".format(name, active, hex, mac))
     if _sta.isconnected():
         print("     connected:", _sta.config("ssid"), end="")
     else:
@@ -164,13 +163,7 @@ def status():
         mode_names = ("MODE_11B", "MODE_11G", "MODE_11N", "MODE_LR")
         protocol = _sta.config("protocol")
         try:
-            p = "|".join(
-                (
-                    x  
-                    for x in mode_names
-                    if protocol & getattr(network, x)  
-                )
-            )
+            p = "|".join((x for x in mode_names if protocol & getattr(network, x)))
         except AttributeError:
             p = ""
         print(", protocol={:d} ({})".format(protocol, p), end="")
@@ -179,4 +172,3 @@ def status():
     print()
     if _sta.isconnected():
         print("     ifconfig:", _sta.ifconfig())
-

--- a/tests/quality_tests/feat_networking/check_socket.py
+++ b/tests/quality_tests/feat_networking/check_socket.py
@@ -1,3 +1,5 @@
+from typing_extensions import assert_type
+
 from socket import socket, AF_INET, SOCK_STREAM, SOCK_DGRAM
 from select import poll
 
@@ -11,3 +13,7 @@ socket(AF_INET, SOCK_DGRAM)
 # poll: () -> _poll
 
 x = poll()
+
+
+received, address = socket(AF_INET, SOCK_DGRAM).recvfrom(1024)
+assert_type(received, bytes)


### PR DESCRIPTION
Improve the WLAN configuration method overloads for better type safety and update the recvfrom return type to include the address as a tuple. Add a test example to assert the type of received data.


closes #913